### PR TITLE
Delete images version 1.1 and older

### DIFF
--- a/templates/jws31-tomcat7-image-stream.json
+++ b/templates/jws31-tomcat7-image-stream.json
@@ -26,46 +26,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Apache Tomcat 7 S2I images.",
-                            "iconClass": "icon-rh-tomcat",
-                            "tags": "builder,tomcat,tomcat7,java,jboss,hidden",
-                            "supports": "tomcat7:3.1,tomcat:7,java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.0",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Apache Tomcat 7"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Apache Tomcat 7 S2I images.",
-                            "iconClass": "icon-rh-tomcat",
-                            "tags": "builder,tomcat,tomcat7,java,jboss,hidden",
-                            "supports": "tomcat7:3.1,tomcat:7,java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Apache Tomcat 7"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-webserver-3/webserver31-tomcat7-openshift:1.1"
-                        }
-                    },
-                    {
                         "name": "1.2",
                         "annotations": {
                             "description": "JBoss Web Server 3.1 Apache Tomcat 7 S2I images.",

--- a/templates/jws31-tomcat8-image-stream.json
+++ b/templates/jws31-tomcat8-image-stream.json
@@ -26,46 +26,6 @@
             "spec": {
                 "tags": [
                     {
-                        "name": "1.0",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Apache Tomcat 8 S2I images.",
-                            "iconClass": "icon-rh-tomcat",
-                            "tags": "builder,tomcat,tomcat8,java,jboss,hidden",
-                            "supports": "tomcat8:3.1,tomcat:8,java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.0",
-                            "openshift.io/display-name": "JBoss Web Server 3.1 Apache Tomcat 8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.0"
-                        }
-                    },
-                    {
-                        "name": "1.1",
-                        "annotations": {
-                            "description": "JBoss Web Server 3.1 Apache Tomcat 8 S2I images.",
-                            "iconClass": "icon-rh-tomcat",
-                            "tags": "builder,tomcat,tomcat8,java,jboss,hidden",
-                            "supports": "tomcat8:3.1,tomcat:8,java:8",
-                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
-                            "sampleContextDir": "tomcat-websocket-chat",
-                            "version": "1.1",
-                            "openshift.io/display-name": "Red Hat JBoss Web Server 3.1 Apache Tomcat 8"
-                        },
-                        "referencePolicy": {
-                            "type": "Local"
-                        },
-                        "from": {
-                            "kind": "DockerImage",
-                            "name": "registry.redhat.io/jboss-webserver-3/webserver31-tomcat8-openshift:1.1"
-                        }
-                    },
-                    {
                         "name": "1.2",
                         "annotations": {
                             "description": "JBoss Web Server 3.1 Apache Tomcat 8 S2I images.",


### PR DESCRIPTION
These old images (last updated four years ago) were built and use Docker version 2 schema 1 manifests, which are deprecated and [no longer supported on the Red Hat Container Catalog](https://access.redhat.com/articles/6138332).  Systems will start throwing errors if they attempt to query these images.

We'll need this merged to stable and a new tag created so that openshift/library can be updated accordingly.

cc @bekionel 

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
